### PR TITLE
Don't assume there are no classes

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = function container_plugin(md, name, options) {
 
     // add a class to the opening tag
     if (tokens[idx].nesting === 1) {
-      tokens[idx].attrPush([ 'class', name ]);
+      tokens[idx].attrJoin('class', name);
     }
 
     return self.renderToken(tokens, idx, _options, env, self);


### PR DESCRIPTION
This plugin has a soft conflict with markdown-it-attrs because it needs a custom render function that doesn't assume the lack of classes on the container. This PR fixes that. 