### PR TITLE
Improve instructions for browser users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,19 +31,27 @@ Difference is, that marker use another character and content is rendered as mark
 
 ## Installation
 
-node.js, browser:
+**node.js** & **bower**:
 
 ```bash
 $ npm install markdown-it-container --save
 $ bower install markdown-it-container --save
 ```
 
+**browser (CDN)**:
+
+* [jsDeliver CDN](https://www.jsdelivr.com/package/npm/markdown-it-container)
 
 ## API
 
 ```js
+// node.js
 var md = require('markdown-it')()
             .use(require('markdown-it-container'), name [, options]);
+
+// browser
+var md =  window.markdownit()
+            .use(window.markdownitContainer, name [, options]);
 ```
 
 Params:
@@ -59,10 +67,7 @@ Params:
 ## Example
 
 ```js
-var md = require('markdown-it')();
-
-md.use(require('markdown-it-container'), 'spoiler', {
-
+var options = {
   validate: function(params) {
     return params.trim().match(/^spoiler\s+(.*)$/);
   },
@@ -79,7 +84,15 @@ md.use(require('markdown-it-container'), 'spoiler', {
       return '</details>\n';
     }
   }
-});
+};
+
+// node.js
+var md = require('markdown-it')();
+md.use(require('markdown-it-container'), 'spoiler', options);
+
+// or browser
+var md = window.markdownit();
+md.use(window.markdownitContainer, 'spoiler', options);
 
 console.log(md.render('::: spoiler click me\n*content*\n:::\n'));
 


### PR DESCRIPTION
If I may soapbox for a minute…

I've been doing research into in-browser Markdown editors and parsers over the last couple weeks for a client project, and all of the ones who have substantial activity in the last couple years all seem very Node-centric, most critically in terms of documentation. Far be it for me to tell other OSS devs how to run their projects, but it really makes me, who only writes JS for browser use and has no interest in doing otherwise, feel like a second-class citizen. Now I know all the cool kids are rewriting the entire world in Node nowadays, but I'm really hoping that today's modern JS library maintainers can remember that there's still a bunch of us old neckbeards trying to figure out how to use their stuff in a browser, where documentation becomes instantly useless the moment it tells us to use `require()`.

With the help of #2, I got markdown-it-container working great for my client's project now, so through this pull request, I'm moving the OSS JavaScript library world a little closer to the world I'd like to see. The format of the changes vaguely match those on the main markdown-it README.